### PR TITLE
feat: add new projects config

### DIFF
--- a/sites-enabled/10-freecodecamp.rocks.conf
+++ b/sites-enabled/10-freecodecamp.rocks.conf
@@ -18,6 +18,7 @@
 # timestamp-microservice
 # twitch-proxy
 # url-shortener-microservice
+# voting-app
 # weather-proxy
 # ---------------------------------
 # american-british-translator.freecodecamp.rocks
@@ -727,4 +728,39 @@ server {
 
   server_name request-header-parser-microservice.freecodecamp.rocks;
   return 301 https://request-header-parser-microservice.freecodecamp.rocks$request_uri;
+}
+
+# ---------------------------------
+# voting-app.freecodecamp.rocks
+# ---------------------------------
+
+server {
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
+
+  server_name voting-app.freecodecamp.rocks;
+
+  # SSL
+  include snippets/common/ssl-freecodecamp-rocks.conf;
+
+  # security
+  include snippets/common/security.conf;
+
+  # reverse proxy the app
+  location / {
+    proxy_pass http://voting-app;
+    include snippets/common/proxy-params.conf;
+  }
+
+  # additional config
+  include snippets/common/general.conf;
+}
+
+# HTTP to HTTPS
+server {
+  listen 80;
+  listen [::]:80;
+
+  server_name voting-app.freecodecamp.rocks;
+  return 301 https://voting-app.freecodecamp.rocks$request_uri;
 }

--- a/sites-enabled/10-freecodecamp.rocks.conf
+++ b/sites-enabled/10-freecodecamp.rocks.conf
@@ -2,6 +2,7 @@
 # american-british-translator
 # anonymous-message-board
 # build-a-pinterest-clone
+# chart-the-stock-market
 # exercise-tracker
 # file-metadata-microservice
 # forum-proxy
@@ -799,4 +800,39 @@ server {
 
   server_name image-search.freecodecamp.rocks;
   return 301 https://image-search.freecodecamp.rocks$request_uri;
+}
+
+# ---------------------------------
+# chart-the-stock-market.freecodecamp.rocks
+# ---------------------------------
+
+server {
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
+
+  server_name chart-the-stock-market.freecodecamp.rocks;
+
+  # SSL
+  include snippets/common/ssl-freecodecamp-rocks.conf;
+
+  # security
+  include snippets/common/security.conf;
+
+  # reverse proxy the app
+  location / {
+    proxy_pass http://chart-the-stock-market;
+    include snippets/common/proxy-params.conf;
+  }
+
+  # additional config
+  include snippets/common/general.conf;
+}
+
+# HTTP to HTTPS
+server {
+  listen 80;
+  listen [::]:80;
+
+  server_name chart-the-stock-market.freecodecamp.rocks;
+  return 301 https://chart-the-stock-market.freecodecamp.rocks$request_uri;
 }

--- a/sites-enabled/10-freecodecamp.rocks.conf
+++ b/sites-enabled/10-freecodecamp.rocks.conf
@@ -5,6 +5,7 @@
 # exercise-tracker
 # file-metadata-microservice
 # forum-proxy
+# image-search-abstraction-layer
 # issue-tracker
 # manage-a-book-trading-club
 # metric-imperial-converter
@@ -763,4 +764,39 @@ server {
 
   server_name voting-app.freecodecamp.rocks;
   return 301 https://voting-app.freecodecamp.rocks$request_uri;
+}
+
+# ---------------------------------
+# image-search.freecodecamp.rocks
+# ---------------------------------
+
+server {
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
+
+  server_name image-search.freecodecamp.rocks;
+
+  # SSL
+  include snippets/common/ssl-freecodecamp-rocks.conf;
+
+  # security
+  include snippets/common/security.conf;
+
+  # reverse proxy the app
+  location / {
+    proxy_pass http://image-search;
+    include snippets/common/proxy-params.conf;
+  }
+
+  # additional config
+  include snippets/common/general.conf;
+}
+
+# HTTP to HTTPS
+server {
+  listen 80;
+  listen [::]:80;
+
+  server_name image-search.freecodecamp.rocks;
+  return 301 https://image-search.freecodecamp.rocks$request_uri;
 }

--- a/sites-enabled/10-freecodecamp.rocks.conf
+++ b/sites-enabled/10-freecodecamp.rocks.conf
@@ -775,7 +775,7 @@ server {
   listen 443 ssl http2;
   listen [::]:443 ssl http2;
 
-  server_name image-search.freecodecamp.rocks;
+  server_name image-search-abstraction-layer.freecodecamp.rocks;
 
   # SSL
   include snippets/common/ssl-freecodecamp-rocks.conf;
@@ -785,7 +785,7 @@ server {
 
   # reverse proxy the app
   location / {
-    proxy_pass http://image-search;
+    proxy_pass http://image-search-abstraction-layer;
     include snippets/common/proxy-params.conf;
   }
 
@@ -798,8 +798,8 @@ server {
   listen 80;
   listen [::]:80;
 
-  server_name image-search.freecodecamp.rocks;
-  return 301 https://image-search.freecodecamp.rocks$request_uri;
+  server_name image-search-abstraction-layer.freecodecamp.rocks;
+  return 301 https://image-search-abstraction-layer.freecodecamp.rocks$request_uri;
 }
 
 # ---------------------------------


### PR DESCRIPTION
I have added these projects to the demo-projects repo and pulled code to the vm - set up the env variables and installed packages. Should just need to adjust the nginx config and start them.

I noticed that the `configs` folder is part of `.gitignore`. We must need to modify that manually?

for upstream.conf file:
```sh
upstream chart-the-stock-market {
  server localhost:50035;
}

upstream image-search-abstraction-layer {
  server localhost:50065;
}

upstream voting-app {
  server localhost:50185;
}
```